### PR TITLE
[Mobile] SC-3 Add common molecules: Error and Screen Header components

### DIFF
--- a/src/components/molecules/error-component.tsx
+++ b/src/components/molecules/error-component.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {View, StyleSheet} from 'react-native';
+import {TextView, CustomButton} from '../atoms';
+import label from '../../translations/en.json';
+
+interface ErrorProps {
+  message: string;
+  buttonText?: string;
+  onButtonPress?: () => void;
+}
+
+const ErrorComponent: React.FC<ErrorProps> = ({
+  message,
+  buttonText = label.try_again,
+  onButtonPress,
+}) => {
+  return (
+    <View style={styles.container}>
+      <TextView style={styles.message}>{message}</TextView>
+      {onButtonPress && (
+        <CustomButton
+          title={buttonText}
+          onPress={onButtonPress}
+          style={styles.button}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  message: {
+    marginBottom: 20,
+  },
+  button: {
+    marginTop: 10,
+  },
+});
+
+export default ErrorComponent;

--- a/src/components/molecules/error-component.tsx
+++ b/src/components/molecules/error-component.tsx
@@ -1,21 +1,51 @@
 import React from 'react';
-import {View, StyleSheet} from 'react-native';
+import {
+  View,
+  StyleSheet,
+  TouchableOpacity,
+  Image,
+  I18nManager,
+} from 'react-native';
 import {TextView, CustomButton} from '../atoms';
 import label from '../../translations/en.json';
+import R from '../../styles';
 
 interface ErrorProps {
   message: string;
   buttonText?: string;
   onButtonPress?: () => void;
+  showBack?: boolean;
+  onBackPress?: () => void;
 }
 
 const ErrorComponent: React.FC<ErrorProps> = ({
   message,
   buttonText = label.try_again,
   onButtonPress,
+  showBack = false,
+  onBackPress,
 }) => {
+  const handleBackPress = () => {
+    if (onBackPress) {
+      onBackPress();
+    }
+  };
+
   return (
     <View style={styles.container}>
+      {showBack && (
+        <TouchableOpacity style={styles.backButton} onPress={handleBackPress}>
+          <Image
+            style={[
+              styles.backIcon,
+              {
+                transform: [{scaleX: I18nManager.isRTL ? -1 : 1}],
+              },
+            ]}
+            source={R.images.crossIcon}
+          />
+        </TouchableOpacity>
+      )}
       <TextView style={styles.message}>{message}</TextView>
       {onButtonPress && (
         <CustomButton
@@ -39,6 +69,16 @@ const styles = StyleSheet.create({
   },
   button: {
     marginTop: 10,
+  },
+  backButton: {
+    position: 'absolute',
+    top: 20,
+    left: 20,
+    zIndex: 1,
+  },
+  backIcon: {
+    width: 24,
+    height: 24,
   },
 });
 

--- a/src/components/molecules/header-component.tsx
+++ b/src/components/molecules/header-component.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import {View, TouchableOpacity, Image, StyleSheet} from 'react-native';
+import R from '../../styles';
+import {TextView} from '../atoms';
+
+interface HeaderViewProps {
+  title: string;
+  onBackPress: () => void;
+  onFavoritePress?: () => void;
+}
+
+const HeaderView: React.FC<HeaderViewProps> = ({
+  title,
+  onBackPress,
+  onFavoritePress,
+}) => {
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity onPress={onBackPress} style={styles.backButton}>
+        <Image source={R.images.crossIcon} style={styles.icon} />
+      </TouchableOpacity>
+      <TextView style={styles.title}>{title}</TextView>
+      {/* TODO: improve it later */}
+      {onFavoritePress && (
+        <TouchableOpacity
+          onPress={onFavoritePress}
+          style={styles.favoriteButton}>
+          <Image source={R.images.crossIcon} style={styles.icon} />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: R.colors.background,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: R.colors.secondary,
+  },
+  backButton: {
+    padding: 8,
+  },
+  title: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  favoriteButton: {
+    padding: 8,
+  },
+  icon: {
+    width: 24,
+    height: 24,
+  },
+});
+
+export default HeaderView;


### PR DESCRIPTION
Ticket No= 3
Ticket Link= [SC-3](https://github.com/users/AsadNajum/projects/2/views/3?pane=issue&itemId=56102469)

**Tasks**
- [x] Error molecule
- [x] Header molecule

**Description**
This PR introduces the addition of two common molecules, Error and Screen Header, which will be utilized across the application for consistent UI elements. These components are designed to enhance usability and maintain a cohesive design language throughout the app.